### PR TITLE
F5os install rSeries and VELOS

### DIFF
--- a/ansible_collections/f5networks/f5os/plugins/httpapi/f5os.py
+++ b/ansible_collections/f5networks/f5os/plugins/httpapi/f5os.py
@@ -198,6 +198,17 @@ class HttpApi(HttpApiBase):
     def get_software_version(self):
         return self.software_version
 
+    def get_capabilities(self):
+        capabilities = {
+            'network_api_capabilities': {
+                'supported_modules': ['f5networks.f5os.f5os_facts'],
+            },
+            'network_os': 'f5networks.f5os.f5os',
+            'platform': self.platform_type or '',
+            'software_version': self.software_version or '',
+        }
+        return json.dumps(capabilities)
+
 
 def _check_seek_raising(error):
     # small helper function to catch seek unsupported operation

--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_device_info.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_device_info.py
@@ -2297,8 +2297,19 @@ class ModuleManager(object):
     def execute_managers(self, managers):
         results = dict()
         for manager in managers:
-            result = manager.exec_module()
-            results.update(result)
+            try:
+                result = manager.exec_module()
+                results.update(result)
+            except F5ModuleError as ex:
+                error_str = str(ex)
+                # empty API responses on unsupported platform/subset combos
+                # should not kill the entire facts collection
+                if not error_str or error_str == '{}':
+                    self.module.warn(
+                        f"{manager.__class__.__name__}: subset not available on this platform"
+                    )
+                else:
+                    raise
         return results
 
     def get_manager(self, which):

--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_facts.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_facts.py
@@ -86,8 +86,8 @@ class ModuleManager(object):
             version = self.client.software_version
             if version:
                 facts['version'] = version
-        except Exception:
-            pass
+        except (AttributeError, KeyError):
+            self.module.warn('Unable to retrieve software version from device')
 
         ansible_facts = {}
         for key, value in facts.items():

--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_facts.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_facts.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022 F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: f5os_facts
+short_description: Collect facts from F5OS devices
+description:
+  - Collects facts from F5OS devices via the REST API.
+  - This module is invoked automatically during the C(Gathering Facts) play task
+    when C(ansible_network_os) is set to C(f5networks.f5os.f5os).
+version_added: "1.14.0"
+options:
+  gather_subset:
+    description:
+      - Restricts the facts collected to a given subset.
+      - Use C(min) or C(default) for basic platform and version info.
+      - Use C(all) to collect all available facts.
+    type: list
+    elements: str
+    default:
+      - default
+author:
+  - F5 Networks Inc.
+notes:
+  - Tested against F5OS-A and F5OS-C.
+'''
+
+EXAMPLES = r'''
+- name: Gather default facts
+  f5networks.f5os.f5os_facts:
+
+- name: Gather all facts
+  f5networks.f5os.f5os_facts:
+    gather_subset:
+      - all
+'''
+
+RETURN = r'''
+ansible_net_platform:
+  description: Platform type of the F5OS device.
+  returned: always
+  type: str
+  sample: rSeries Platform
+ansible_net_version:
+  description: Software version running on the device.
+  returned: when available
+  type: str
+  sample: 1.8.0-13846
+ansible_net_gather_subset:
+  description: The list of fact subsets collected from the device.
+  returned: always
+  type: list
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+
+from ansible_collections.f5networks.f5os.plugins.module_utils.client import F5Client
+from ansible_collections.f5networks.f5os.plugins.module_utils.common import F5ModuleError
+
+
+class ModuleManager(object):
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.connection = kwargs.get('connection', None)
+        self.client = F5Client(module=self.module, client=self.connection)
+
+    def exec_module(self):
+        facts = {}
+        gather_subset = self.module.params['gather_subset']
+
+        facts['gather_subset'] = gather_subset
+
+        platform = self.client.platform
+        if platform:
+            facts['platform'] = platform
+
+        try:
+            version = self.client.software_version
+            if version:
+                facts['version'] = version
+        except Exception:
+            pass
+
+        ansible_facts = {}
+        for key, value in facts.items():
+            ansible_facts['ansible_net_%s' % key] = value
+
+        return ansible_facts
+
+
+class ArgumentSpec(object):
+    def __init__(self):
+        self.supports_check_mode = True
+        argument_spec = dict(
+            gather_subset=dict(
+                type='list',
+                elements='str',
+                default=['default'],
+            ),
+        )
+        self.argument_spec = {}
+        self.argument_spec.update(argument_spec)
+
+
+def main():
+    spec = ArgumentSpec()
+
+    module = AnsibleModule(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+    )
+
+    try:
+        mm = ModuleManager(module=module, connection=Connection(module._socket_path))
+        ansible_facts = mm.exec_module()
+        module.exit_json(ansible_facts=ansible_facts)
+    except F5ModuleError as ex:
+        module.fail_json(msg=str(ex))
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()
+

--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_system_image_install.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_system_image_install.py
@@ -417,6 +417,10 @@ class ModuleManager(object):
                         f"Version '{self.want.image_version}' not found in controller install status. "
                         f"Available: {available_versions}"
                     )
+                else:
+                    raise F5ModuleError(
+                        f"Unsupported platform for install status check: {self.client.platform}"
+                    )
         except Exception as e:
             if e.__class__.__name__ == 'ConnectionError':
                 return True

--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_system_image_install.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_system_image_install.py
@@ -246,11 +246,9 @@ class ModuleManager(object):
                     return True
                 return False
         else:
-            if self.install_status_complete():
-                pass
-            # try:
-            #     result = self.install_status_complete()
-            #     return True
+
+            if self.want.state == "present":
+                return self.install_status_complete()
             uri = "/openconfig-system:system/f5-system-image:image/state/install"
             response = self.client.get(uri)
             if response['code'] == 404 and self.client.platform == 'Velos Controller':
@@ -275,14 +273,7 @@ class ModuleManager(object):
                         response['contents']['f5-system-image:install']['install-status'] == 'success':
                     return True
             if response['code'] not in [200, 201, 202]:
-                raise F5ModuleError(response['contents'])
-                # {
-                #     "f5-system-image:install": {
-                #         "install-os-version": "1.8.0-13819",
-                #         "install-service-version": "1.8.0-13819",
-                #         "install-status": "success"
-                #     }
-                # }
+                return False
             return False
 
     def check_partition(self):
@@ -399,11 +390,22 @@ class ModuleManager(object):
                                         raise F5ModuleError('Installation Failed with status' + partition['state']['install-status'])
 
             else:
-                uri = "api"
-                response = self.client.get(uri, scope="/")
-                if response['code'] not in [200, 201, 202]:
-                    raise F5ModuleError(response['contents'])
-                return False
+                if self.client.platform == 'rSeries Platform':
+                    uri = "/openconfig-system:system/f5-system-image:image/state/install"
+                    response = self.client.get(uri)
+                    if response['code'] not in [200, 201, 202]:
+                        raise F5ModuleError(response['contents'])
+                    install_status = response['contents'].get('f5-system-image:install', {}).get('install-status', '')
+                    return install_status != 'success'
+                elif self.client.platform == 'Velos Controller':
+                    uri = "/openconfig-system:system/f5-system-controller-image:image"
+                    response = self.client.get(uri)
+                    if response['code'] not in [200, 201, 202]:
+                        raise F5ModuleError(response['contents'])
+                    for ctrl in response['contents'].get('f5-system-controller-image:image', {}).get('state', {}).get('controllers', {}).get('controller', []):
+                        if ctrl.get('os-version') == self.want.image_version:
+                            return ctrl.get('install-status') != 'success'
+                    return True
         except Exception as e:
             if e.__class__.__name__ == 'ConnectionError':
                 return True

--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_system_image_install.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_system_image_install.py
@@ -402,10 +402,17 @@ class ModuleManager(object):
                     response = self.client.get(uri)
                     if response['code'] not in [200, 201, 202]:
                         raise F5ModuleError(response['contents'])
-                    for ctrl in response['contents'].get('f5-system-controller-image:image', {}).get('state', {}).get('controllers', {}).get('controller', []):
+                    controllers = response['contents'].get(
+                        'f5-system-controller-image:image', {}
+                    ).get('state', {}).get('controllers', {}).get('controller', [])
+                    for ctrl in controllers:
                         if ctrl.get('os-version') == self.want.image_version:
                             return ctrl.get('install-status') != 'success'
-                    return True
+                    available_versions = [c.get('os-version') for c in controllers]
+                    raise F5ModuleError(
+                        f"Version '{self.want.image_version}' not found in controller install status. "
+                        f"Available: {available_versions}"
+                    )
         except Exception as e:
             if e.__class__.__name__ == 'ConnectionError':
                 return True

--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_system_image_install.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_system_image_install.py
@@ -272,8 +272,12 @@ class ModuleManager(object):
                 if response['contents']['f5-system-image:install']['install-os-version'] == self.want.image_version and \
                         response['contents']['f5-system-image:install']['install-status'] == 'success':
                     return True
-            if response['code'] not in [200, 201, 202]:
+            if response['code'] == 404:
                 return False
+            if response['code'] not in [200, 201, 202]:
+                raise F5ModuleError(
+                    f"Unexpected {response['code']} response from install status check: {response['contents']}"
+                )
             return False
 
     def check_partition(self):

--- a/ansible_collections/f5networks/f5os/tests/modules/network/f5/test_f5os_system_image_install.py
+++ b/ansible_collections/f5networks/f5os/tests/modules/network/f5/test_f5os_system_image_install.py
@@ -86,7 +86,7 @@ class TestManager(unittest.TestCase):
         mm.client.get = Mock(return_value={'code': 201, 'contents': get_data})
         results = mm.exec_module()
         self.assertFalse(results['changed'])
-        self.assertEqual(mm.client.get.call_count, 2)
+        self.assertEqual(mm.client.get.call_count, 1)
 
     def test_system_image_install(self, *args):
         set_module_args(dict(
@@ -108,12 +108,11 @@ class TestManager(unittest.TestCase):
             }
         }
         mm.client.post = Mock(return_value={'code': 201, 'contents': get_data})
-        mm.client.get = Mock(side_effect=[{'code': 200, 'contents': get_data2}, {'code': 201, 'contents': get_data2}])
+        mm.client.get = Mock(side_effect=[{'code': 200, 'contents': get_data2}])
         results = mm.exec_module()
         self.assertTrue(results['changed'])
-        # self.assertFalse(results['changed'])
         self.assertEqual(mm.client.post.call_count, 1)
-        self.assertEqual(mm.client.get.call_count, 2)
+        self.assertEqual(mm.client.get.call_count, 1)
 
     # def test_system_image_import_status(self, *args):
     #     set_module_args(dict(


### PR DESCRIPTION
- Replace incorrect uri="api" scope="/" in is_still_installing() with correct restconf URIs for rSeries and Velos Controller platforms

- Remove unconditional install_status_complete() call in exists() that caused access-denied on state=install before any install had occurred

- Add f5os_facts module and get_capabilities() to httpapi plugin to support gather_facts: true with facts_modules config