### PR TITLE
add tls_ca_certificate parameter to f5os_auth_ldap module

### DIFF
--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_auth_ldap.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_auth_ldap.py
@@ -81,6 +81,10 @@ options:
             - Specifies whether to use Unix attributes for the LDAP search
             - Unix attributes does not apply to Velos Partition.
         type: bool
+    tls_ca_certificate:
+        description:
+            - Specifies the TLS certificate from a CA which signed the certificate of the LDAP server
+            - Applies only when C(tls) is set to C(start_tls) or C(on).
     tls_certificate:
         description:
             - Specifies the TLS certificate to be used for the LDAP search
@@ -173,6 +177,10 @@ unix_attributes:
   description: Whether to use Unix attributes for the LDAP search.
   returned: changed
   type: bool
+tls_ca_certificate:
+  description: TLS certificate from a CA which signed the certificate of the LDAP server.
+  returned: changed
+  type: str
 tls_certificate:
   description: TLS certificate to be used for the LDAP search.
   returned: changed
@@ -213,6 +221,7 @@ class Parameters(AnsibleF5Parameters):
         'tls_ciphers',
         'active_directory',
         'unix_attributes',
+        'tls_ca_certificate',
         'tls_certificate',
         'tls_key'
     ]
@@ -234,6 +243,7 @@ class Parameters(AnsibleF5Parameters):
         'tls_ciphers',
         'active_directory',
         'unix_attributes',
+        'tls_ca_certificate',
         'tls_certificate',
         'tls_key'
     ]
@@ -317,6 +327,12 @@ class ApiParameters(Parameters):
     def unix_attributes(self):
         if 'unix_attributes' in self._values:
             return self._values['unix_attributes']
+        return None
+
+    @property
+    def tls_ca_certificate(self):
+        if 'tls_cacert' in self._values:
+            return self._values['tls_cacert']
         return None
 
     @property
@@ -485,6 +501,7 @@ class ModuleManager(object):
                 "tls_ciphers": params.get("tls_ciphers") if params.get("tls_ciphers") is not None else self.have.tls_ciphers,
                 "active_directory": params.get("active_directory") if params.get("active_directory") is not None else self.have.active_directory,
                 "unix_attributes": params.get("unix_attributes") if params.get("unix_attributes") is not None else self.have.unix_attributes,
+                "tls_cacert": params.get("tls_ca_certificate") if params.get("tls_ca_certificate") is not None else self.have.tls_ca_certificate,
                 "tls_cert": params.get("tls_certificate") if params.get("tls_certificate") is not None else self.have.tls_certificate,
                 "tls_key": params.get("tls_key") if params.get("tls_key") is not None else self.have.tls_key,
             }
@@ -535,6 +552,7 @@ class ArgumentSpec(object):
             tls_ciphers=dict(type='str'),
             active_directory=dict(type='bool'),
             unix_attributes=dict(type='bool'),
+            tls_ca_certificate=dict(type='str'),
             tls_certificate=dict(type='str'),
             tls_key=dict(type='str', no_log=True),
         )


### PR DESCRIPTION
This PR enhances the f5os_auth_ldap module by adding support for configuring the TLS CA certificate used for LDAP authentication.

- Introduces a new module parameter: `tls_ca_certificate`
- The parameter maps directly to the `tls_cacert` setting in the F5OS OpenConfig API
[https://clouddocs.f5.com/api/rseries-api/F5OS-A-1.8.3-api.html?section=openconfig-system#operation/data_openconfig_system_system_aaa_authentication_f5_openconfig_aaa_ldap_ldap_f5_openconfig_aaa_ldap_tls_cacert_put](https://clouddocs.f5.com/api/rseries-api/F5OS-A-1.8.3-api.html?section=openconfig-system#operation/data_openconfig_system_system_aaa_authentication_f5_openconfig_aaa_ldap_ldap_f5_openconfig_aaa_ldap_tls_cacert_put)
- This change may resolve #36

Tested with: 
- Python 3.10.12
- Ansible 2.17.14
- F5OS 1.8.3
