### PR TITLE
Ldap bindpw

### DIFF
--- a/ansible_collections/f5networks/f5os/CHANGELOG.rst
+++ b/ansible_collections/f5networks/f5os/CHANGELOG.rst
@@ -27,6 +27,7 @@ Bugfixes
 - f5os_system_image_install - Raise error for unsupported platform in install status check instead of silently returning None.
 - f5os_device_info - Handle empty API errors for unsupported subsets when using gather_subset all.
 - f5os_facts - Narrow exception handling for software version retrieval and emit warning instead of silently swallowing errors.
+- f5os_auth_ldap - Fixed bind_password parameter being silently ignored. Added update_password parameter (always/on_create) to control bind password update behavior.
 
 New Modules
 -----------

--- a/ansible_collections/f5networks/f5os/CHANGELOG.rst
+++ b/ansible_collections/f5networks/f5os/CHANGELOG.rst
@@ -126,6 +126,7 @@ Bugfixes
 New Modules
 -----------
 
+- f5networks.f5os.f5os_auth_ldap - Manage LDAP common configuration on F5OS systems.
 - f5networks.f5os.f5os_auth_server - Manage Auth Server Groups and Server inside it.
 - f5networks.f5os.f5os_fdb - Manage Layer 2 forwarding database (FDB) entry in the system
 - f5networks.f5os.f5os_qos_traffic_priority - Manage QoS Traffic Priorities on F5OS

--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_auth_ldap.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_auth_ldap.py
@@ -106,8 +106,8 @@ notes:
     - The parameters not specified in the module will not be updated and will remain unchanged.
     - The F5OS API returns the bind password as an encrypted ciphertext that changes on every request, making direct comparison impossible.
     - When C(update_password) is set to C(always) (the default), the bind password will be sent on
-    every run, reporting a change each time. Set C(update_password) to C(on_create) to only set
-    the password when no password is currently configured.
+      every run, reporting a change each time. Set C(update_password) to C(on_create) to only set
+      the password when no password is currently configured.
 author:
     - Prateek Ramani (@ramani)
 '''

--- a/ansible_collections/f5networks/f5os/plugins/modules/f5os_auth_ldap.py
+++ b/ansible_collections/f5networks/f5os/plugins/modules/f5os_auth_ldap.py
@@ -28,6 +28,15 @@ options:
         description:
             - Specifies the bind password for the LDAP search
         type: str
+    update_password:
+        description:
+            - C(always) will always update the C(bind_password) when it is specified.
+            - C(on_create) will only set the C(bind_password) when no bind password is currently configured on the device.
+        type: str
+        choices:
+            - always
+            - on_create
+        default: always
     bind_timeout:
         description:
             - Specifies the bind timeout for the LDAP search
@@ -93,9 +102,12 @@ options:
         type: str
 
 notes:
-    - This Module makes a PUT request to the F5OS system to update the LDAP common configuration.
+    - This module makes a PUT request to the F5OS system to update the LDAP common configuration.
     - The parameters not specified in the module will not be updated and will remain unchanged.
-    - Changes on Bind Password will not be detected by the module.
+    - The F5OS API returns the bind password as an encrypted ciphertext that changes on every request, making direct comparison impossible.
+    - When C(update_password) is set to C(always) (the default), the bind password will be sent on
+    every run, reporting a change each time. Set C(update_password) to C(on_create) to only set
+    the password when no password is currently configured.
 author:
     - Prateek Ramani (@ramani)
 '''
@@ -118,6 +130,12 @@ EXAMPLES = r'''
     active_directory: true
     unix_attributes: false
 
+- name: Set LDAP bind password only if not already configured
+  f5os_auth_ldap:
+    bind_dn: "cn=admin,dc=example,dc=com"
+    bind_password: "password"
+    update_password: on_create
+
 '''
 
 RETURN = r'''
@@ -130,7 +148,7 @@ bind_dn:
   returned: changed
   type: str
 bind_password:
-  description: Bind password for the LDAP search.
+  description: Bind password for the LDAP search. Always returns C(None) for security purposes.
   returned: changed
   type: str
 bind_timeout:
@@ -223,7 +241,7 @@ class Parameters(AnsibleF5Parameters):
     updatables = [
         'base_dn',
         'bind_dn',
-        # 'bind_password',
+        'bind_password',
         'bind_timeout',
         'read_timeout',
         'idle_timeout',
@@ -353,7 +371,9 @@ class UsableChanges(Changes):
 
 
 class ReportableChanges(Changes):
-    pass
+    @property
+    def bind_password(self):
+        return None
 
 
 class Difference(object):  # pragma: no cover
@@ -375,6 +395,17 @@ class Difference(object):  # pragma: no cover
             return None
         if tls == 'start_tls' or tls == 'on':
             return self.__default(param)
+        return None
+
+    @property
+    def bind_password(self):
+        if self.want.bind_password is None:
+            return None
+        if self.want.update_password == 'always':
+            return self.want.bind_password
+        if self.want.update_password == 'on_create':
+            if self.have.bind_password is None:
+                return self.want.bind_password
         return None
 
     def __default(self, param):
@@ -409,9 +440,7 @@ class ModuleManager(object):
         updatables = Parameters.updatables
         changed = dict()
         for k in updatables:
-
             change = diff.compare(k)
-
             if change is None:
                 continue
             else:
@@ -436,7 +465,9 @@ class ModuleManager(object):
         start = datetime.datetime.now().isoformat()
         changed = False
         result = dict()
+
         changed = self.present()
+
         reportable = ReportableChanges(params=self.changes.to_return())
         changes = reportable.to_return()
         result.update(**changes)
@@ -468,29 +499,43 @@ class ModuleManager(object):
     def update_on_device(self):
         '''API communication to actually update the objects on the F5OS system'''
         params = self.changes.api_params()
+
         base_uri = "/openconfig-system:system/aaa/authentication/f5-openconfig-aaa-ldap:ldap"
         payload = {
             "f5-openconfig-aaa-ldap:ldap": {
                 "base": [params.get("base_dn") if params.get("base_dn") is not None else self.have.base_dn],
                 "binddn": params.get("bind_dn") if params.get("bind_dn") is not None else self.have.bind_dn,
-                "bindpw": params.get("bind_password") if params.get("bind_password") is not None else self.have.bind_password,
-                "bind_timelimit": params.get("bind_timeout") if params.get("bind_timeout") is not None else self.have.bind_timeout,
-                "timelimit": params.get("read_timeout") if params.get("read_timeout") is not None else self.have.read_timeout,
-                "idle_timelimit": params.get("idle_timeout") if params.get("idle_timeout") is not None else self.have.idle_timeout,
-                "ldap_version": params.get("ldap_version") if params.get("ldap_version") is not None else self.have.ldap_version,
-                "chase-referrals": params.get("chase_referrals") if params.get("chase_referrals") is not None else self.have.chase_referrals,
+                "bindpw": params.get("bind_password") if params.get("bind_password") is not None
+                else self.have.bind_password,
+                "bind_timelimit": params.get("bind_timeout") if params.get("bind_timeout") is not None
+                else self.have.bind_timeout,
+                "timelimit": params.get("read_timeout") if params.get("read_timeout") is not None
+                else self.have.read_timeout,
+                "idle_timelimit": params.get("idle_timeout") if params.get("idle_timeout") is not None
+                else self.have.idle_timeout,
+                "ldap_version": params.get("ldap_version") if params.get("ldap_version") is not None
+                else self.have.ldap_version,
+                "chase-referrals": params.get("chase_referrals") if params.get("chase_referrals") is not None
+                else self.have.chase_referrals,
                 "ssl": params.get("tls") if params.get("tls") is not None else self.have.tls,
-                "tls_reqcert": params.get("tls_certificate_validation") if params.get("tls_certificate_validation")
-                is not None else self.have.tls_certificate_validation,
-                "tls_ciphers": params.get("tls_ciphers") if params.get("tls_ciphers") is not None else self.have.tls_ciphers,
-                "active_directory": params.get("active_directory") if params.get("active_directory") is not None else self.have.active_directory,
-                "unix_attributes": params.get("unix_attributes") if params.get("unix_attributes") is not None else self.have.unix_attributes,
-                "tls_cert": params.get("tls_certificate") if params.get("tls_certificate") is not None else self.have.tls_certificate,
-                "tls_key": params.get("tls_key") if params.get("tls_key") is not None else self.have.tls_key,
+                "tls_reqcert": params.get("tls_certificate_validation")
+                if params.get("tls_certificate_validation") is not None
+                else self.have.tls_certificate_validation,
+                "tls_ciphers": params.get("tls_ciphers") if params.get("tls_ciphers") is not None
+                else self.have.tls_ciphers,
+                "active_directory": params.get("active_directory") if params.get("active_directory") is not None
+                else self.have.active_directory,
+                "unix_attributes": params.get("unix_attributes") if params.get("unix_attributes") is not None
+                else self.have.unix_attributes,
+                "tls_cert": params.get("tls_certificate") if params.get("tls_certificate") is not None
+                else self.have.tls_certificate,
+                "tls_key": params.get("tls_key") if params.get("tls_key") is not None
+                else self.have.tls_key,
             }
         }
 
-        keys_to_remove = [k for k, v in payload["f5-openconfig-aaa-ldap:ldap"].items() if v is None or (isinstance(v, list) and (len(v) == 0 or v[0] is None))]
+        keys_to_remove = [k for k, v in payload["f5-openconfig-aaa-ldap:ldap"].items()
+                          if v is None or (isinstance(v, list) and (len(v) == 0 or v[0] is None))]
         for k in keys_to_remove:
             payload["f5-openconfig-aaa-ldap:ldap"].pop(k)
 
@@ -504,6 +549,7 @@ class ModuleManager(object):
         uri = "/openconfig-system:system/aaa/authentication/f5-openconfig-aaa-ldap:ldap/"
 
         response = self.client.get(uri)
+
         if 'f5-openconfig-aaa-ldap:ldap' in response['contents']:
             return_object = response['contents']['f5-openconfig-aaa-ldap:ldap']
         else:
@@ -511,6 +557,7 @@ class ModuleManager(object):
 
         if response['code'] not in [200, 201, 202, 204]:
             raise F5ModuleError(response['contents'])  # pragma: no cover
+
         return ApiParameters(params=return_object)
 
 
@@ -521,6 +568,11 @@ class ArgumentSpec(object):
             base_dn=dict(type='str'),
             bind_dn=dict(type='str'),
             bind_password=dict(type='str', no_log=True),
+            update_password=dict(
+                default='always',
+                choices=['always', 'on_create'],
+                no_log=False
+            ),
             bind_timeout=dict(type='int'),
             read_timeout=dict(type='int'),
             idle_timeout=dict(type='int'),

--- a/ansible_collections/f5networks/f5os/tests/modules/network/f5/fixtures/f5os_auth_ldap_current.json
+++ b/ansible_collections/f5networks/f5os/tests/modules/network/f5/fixtures/f5os_auth_ldap_current.json
@@ -1,0 +1,1 @@
+{"f5-openconfig-aaa-ldap:ldap":{"base":["dc=example,dc=com"],"binddn":"cn=admin,dc=example,dc=com","bindpw":"$8$AAAAAAAAAAAAAAAAAAAAAA==","bind_timelimit":10,"timelimit":30,"idle_timelimit":300,"ldap_version":3,"chase-referrals":true,"ssl":"off","tls_reqcert":"demand","tls_ciphers":"HIGH:!aNULL:!MD5","active_directory":true,"unix_attributes":false}}

--- a/ansible_collections/f5networks/f5os/tests/modules/network/f5/fixtures/f5os_auth_ldap_no_bindpw.json
+++ b/ansible_collections/f5networks/f5os/tests/modules/network/f5/fixtures/f5os_auth_ldap_no_bindpw.json
@@ -1,0 +1,1 @@
+{"f5-openconfig-aaa-ldap:ldap":{"base":["dc=example,dc=com"],"binddn":"cn=admin,dc=example,dc=com","bind_timelimit":10,"timelimit":30,"idle_timelimit":300,"ldap_version":3,"chase-referrals":true,"ssl":"off","tls_reqcert":"demand","tls_ciphers":"HIGH:!aNULL:!MD5","active_directory":true,"unix_attributes":false}}

--- a/ansible_collections/f5networks/f5os/tests/modules/network/f5/test_f5os_auth_ldap.py
+++ b/ansible_collections/f5networks/f5os/tests/modules/network/f5/test_f5os_auth_ldap.py
@@ -1,0 +1,328 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2022, F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.f5networks.f5os.plugins.modules import f5os_auth_ldap
+from ansible_collections.f5networks.f5os.plugins.modules.f5os_auth_ldap import (
+    ModuleParameters,
+    ApiParameters,
+    ArgumentSpec,
+    Difference,
+    ModuleManager,
+    ReportableChanges,
+)
+
+from ansible_collections.f5networks.f5os.plugins.module_utils.common import F5ModuleError
+
+from ansible_collections.f5networks.f5os.tests.compat import unittest
+from ansible_collections.f5networks.f5os.tests.compat.mock import (
+    Mock, patch
+)
+from ansible_collections.f5networks.f5os.tests.modules.utils import (
+    set_module_args, exit_json, fail_json, AnsibleFailJson, AnsibleExitJson
+)
+
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+    if path in fixture_data:
+        return fixture_data[path]
+    with open(path) as f:
+        data = f.read()
+    try:
+        data = json.loads(data)
+    except Exception:
+        pass
+    fixture_data[path] = data
+    return data
+
+
+class TestParameters(unittest.TestCase):
+
+    def test_module_parameters_with_bind_password(self):
+        args = dict(
+            base_dn="dc=example,dc=com",
+            bind_dn="cn=admin,dc=example,dc=com",
+            bind_password="secret123",
+            update_password='always',
+            bind_timeout=10,
+        )
+        p = ModuleParameters(params=args)
+        self.assertEqual(p.base_dn, "dc=example,dc=com")
+        self.assertEqual(p.bind_dn, "cn=admin,dc=example,dc=com")
+        self.assertEqual(p.bind_password, "secret123")
+        self.assertEqual(p.bind_timeout, 10)
+
+    def test_api_parameters_with_encrypted_bindpw(self):
+        args = {
+            'base': ['dc=example,dc=com'],
+            'binddn': 'cn=admin,dc=example,dc=com',
+            'bindpw': '$8$encrypted_aes_string',
+            'bind_timelimit': 10,
+            'timelimit': 30,
+            'idle_timelimit': 300,
+            'ldap_version': 3,
+            'ssl': 'off',
+        }
+        p = ApiParameters(params=args)
+        self.assertEqual(p.base_dn, "dc=example,dc=com")
+        self.assertEqual(p.bind_dn, "cn=admin,dc=example,dc=com")
+        self.assertEqual(p.bind_password, "$8$encrypted_aes_string")
+        self.assertEqual(p.bind_timeout, 10)
+
+    def test_api_parameters_with_no_bindpw(self):
+        args = {
+            'base': ['dc=example,dc=com'],
+            'binddn': 'cn=admin,dc=example,dc=com',
+            'bind_timelimit': 10,
+        }
+        p = ApiParameters(params=args)
+        self.assertIsNone(p.bind_password)
+
+
+class TestDifference(unittest.TestCase):
+
+    def test_bind_password_always_returns_wanted(self):
+        want = ModuleParameters(params=dict(
+            bind_password='newpassword',
+            update_password='always',
+        ))
+        have = ApiParameters(params=dict(
+            bindpw='$8$encrypted_aes_string',
+        ))
+        diff = Difference(want, have)
+        result = diff.compare('bind_password')
+        self.assertEqual(result, 'newpassword')
+
+    def test_bind_password_always_returns_wanted_even_if_none_on_device(self):
+        want = ModuleParameters(params=dict(
+            bind_password='newpassword',
+            update_password='always',
+        ))
+        have = ApiParameters(params=dict())
+        diff = Difference(want, have)
+        result = diff.compare('bind_password')
+        self.assertEqual(result, 'newpassword')
+
+    def test_bind_password_on_create_sets_when_no_existing(self):
+        want = ModuleParameters(params=dict(
+            bind_password='newpassword',
+            update_password='on_create',
+        ))
+        have = ApiParameters(params=dict())
+        diff = Difference(want, have)
+        result = diff.compare('bind_password')
+        self.assertEqual(result, 'newpassword')
+
+    def test_bind_password_on_create_skips_when_existing(self):
+        want = ModuleParameters(params=dict(
+            bind_password='newpassword',
+            update_password='on_create',
+        ))
+        have = ApiParameters(params=dict(
+            bindpw='$8$encrypted_aes_string',
+        ))
+        diff = Difference(want, have)
+        result = diff.compare('bind_password')
+        self.assertIsNone(result)
+
+    def test_bind_password_none_when_not_specified(self):
+        want = ModuleParameters(params=dict(
+            update_password='always',
+        ))
+        have = ApiParameters(params=dict(
+            bindpw='$8$encrypted_aes_string',
+        ))
+        diff = Difference(want, have)
+        result = diff.compare('bind_password')
+        self.assertIsNone(result)
+
+
+class TestReportableChanges(unittest.TestCase):
+
+    def test_bind_password_not_returned(self):
+        changes = ReportableChanges(params=dict(bind_password='secret'))
+        self.assertIsNone(changes.bind_password)
+
+
+class TestManager(unittest.TestCase):
+
+    def setUp(self):
+        self.spec = ArgumentSpec()
+        self.mock_module_helper = patch.multiple(
+            AnsibleModule, exit_json=exit_json, fail_json=fail_json
+        )
+        self.mock_module_helper.start()
+        self.p1 = patch(
+            'ansible_collections.f5networks.f5os.plugins.modules.f5os_auth_ldap.F5Client'
+        )
+        self.m1 = self.p1.start()
+        self.m1.return_value = Mock()
+        self.p2 = patch(
+            'ansible_collections.f5networks.f5os.plugins.modules.f5os_auth_ldap.send_teem'
+        )
+        self.m2 = self.p2.start()
+        self.m2.return_value = True
+
+    def tearDown(self):
+        self.p1.stop()
+        self.p2.stop()
+        self.mock_module_helper.stop()
+
+    def test_update_bind_password_always(self):
+        """bind_password should be sent when update_password=always (default)."""
+        set_module_args(dict(
+            bind_password='newpassword',
+        ))
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+        )
+
+        current = load_fixture('f5os_auth_ldap_current.json')
+        mm = ModuleManager(module=module)
+        mm.client.get = Mock(return_value=dict(code=200, contents=current))
+        mm.client.put = Mock(return_value=dict(code=200, contents=dict()))
+
+        results = mm.exec_module()
+
+        self.assertTrue(results['changed'])
+        mm.client.put.assert_called_once()
+
+    def test_update_bind_password_on_create_no_existing(self):
+        """bind_password should be sent when update_password=on_create and no password exists."""
+        set_module_args(dict(
+            bind_password='newpassword',
+            update_password='on_create',
+        ))
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+        )
+
+        current = load_fixture('f5os_auth_ldap_no_bindpw.json')
+        mm = ModuleManager(module=module)
+        mm.client.get = Mock(return_value=dict(code=200, contents=current))
+        mm.client.put = Mock(return_value=dict(code=200, contents=dict()))
+
+        results = mm.exec_module()
+
+        self.assertTrue(results['changed'])
+        mm.client.put.assert_called_once()
+
+    def test_update_bind_password_on_create_skips_existing(self):
+        """bind_password should NOT be sent when update_password=on_create and password exists."""
+        set_module_args(dict(
+            bind_password='newpassword',
+            update_password='on_create',
+        ))
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+        )
+
+        current = load_fixture('f5os_auth_ldap_current.json')
+        mm = ModuleManager(module=module)
+        mm.client.get = Mock(return_value=dict(code=200, contents=current))
+        mm.client.put = Mock(return_value=dict(code=200, contents=dict()))
+
+        results = mm.exec_module()
+
+        self.assertFalse(results['changed'])
+        mm.client.put.assert_not_called()
+
+    def test_update_without_bind_password(self):
+        """When bind_password is not specified, changing another param should work."""
+        set_module_args(dict(
+            bind_timeout=20,
+        ))
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+        )
+
+        current = load_fixture('f5os_auth_ldap_current.json')
+        mm = ModuleManager(module=module)
+        mm.client.get = Mock(return_value=dict(code=200, contents=current))
+        mm.client.put = Mock(return_value=dict(code=200, contents=dict()))
+
+        results = mm.exec_module()
+
+        self.assertTrue(results['changed'])
+        mm.client.put.assert_called_once()
+
+    def test_no_change_when_nothing_different(self):
+        """No change when all specified params match current state."""
+        set_module_args(dict(
+            base_dn='dc=example,dc=com',
+            bind_dn='cn=admin,dc=example,dc=com',
+            bind_timeout=10,
+        ))
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+        )
+
+        current = load_fixture('f5os_auth_ldap_current.json')
+        mm = ModuleManager(module=module)
+        mm.client.get = Mock(return_value=dict(code=200, contents=current))
+
+        results = mm.exec_module()
+
+        self.assertFalse(results['changed'])
+
+    def test_bind_password_not_leaked_in_results(self):
+        """Verify bind_password is not present in module results."""
+        set_module_args(dict(
+            bind_password='newpassword',
+        ))
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+        )
+
+        current = load_fixture('f5os_auth_ldap_current.json')
+        mm = ModuleManager(module=module)
+        mm.client.get = Mock(return_value=dict(code=200, contents=current))
+        mm.client.put = Mock(return_value=dict(code=200, contents=dict()))
+
+        results = mm.exec_module()
+
+        self.assertTrue(results['changed'])
+        self.assertNotIn('bind_password', results)
+
+    @patch.object(f5os_auth_ldap, 'Connection')
+    @patch.object(f5os_auth_ldap.ModuleManager, 'exec_module',
+                  Mock(return_value={'changed': False}))
+    def test_main_function_success(self, *args):
+        set_module_args(dict(
+            base_dn='dc=example,dc=com',
+        ))
+        with self.assertRaises(AnsibleExitJson) as result:
+            f5os_auth_ldap.main()
+        self.assertFalse(result.exception.args[0]['changed'])
+
+    @patch.object(f5os_auth_ldap, 'Connection')
+    @patch.object(f5os_auth_ldap.ModuleManager, 'exec_module',
+                  Mock(side_effect=F5ModuleError('This module has failed.')))
+    def test_main_function_failed(self, *args):
+        set_module_args(dict(
+            base_dn='dc=example,dc=com',
+        ))
+        with self.assertRaises(AnsibleFailJson) as result:
+            f5os_auth_ldap.main()
+        self.assertTrue(result.exception.args[0]['failed'])
+        self.assertIn('This module has failed', result.exception.args[0]['msg'])


### PR DESCRIPTION
### Problem

The `f5os_auth_ldap` module accepts `bind_password` as a user configurable variable but silently ignores it — the bindpw is never applied to the device, not even on initial configuration. This is because `bind_password` was commented out of the `updatables` list, so it never enters the change detection pipeline and is never sent to the F5OS API.

The original developer likely did this because the F5OS API returns `bindpw` as an AES-encrypted ciphertext that changes on every PUT request, which would always force a change and break idempotency.

### Solution

Following the same approach used in the `f5os_primary_key` module fix (ID1754349) and the `bigip_device_auth_ldap` module in the `f5_modules` collection:

- Uncommented `bind_password` in the `updatables` list
- Added `update_password` parameter (`always` / `on_create`, default `always`)
  - `always` — sends the bind password on every run (will report `changed` each time since ciphertext comparison is impossible)
  - `on_create` — only sets the bind password when no password is currently configured on the device
- Added `Difference.bind_password` property to bypass the impossible ciphertext comparison
- Added `ReportableChanges.bind_password` returning `None` to prevent password leakage in module output
- Added example showing `update_password: on_create` usage
- Added missing `f5os_auth_ldap` entry to v1.15.0 CHANGELOG
- Updated module documentation and notes

### Testing

- Unit tests covering all `bind_password` × `update_password` combinations
- Integration test playbook validating against a live F5OS device
- Patched collection tarball available for customer validation

### References

- [GitHub Issue #36 — Add to the f5os_auth module common LDAP config](https://github.com/F5Networks/f5-ansible-f5os/issues/36)
- INFRAANO-1984
- ID1754349 (`f5os_primary_key` precedent for `update_password` pattern)